### PR TITLE
Fix org-src-lang-modes

### DIFF
--- a/ob-ammonite.el
+++ b/ob-ammonite.el
@@ -36,7 +36,7 @@
 (require 'xterm-color)
 
 (add-to-list 'org-babel-tangle-lang-exts '("amm" . "scala"))
-(add-to-list 'org-src-lang-modes '("amm" . "scala"))
+(add-to-list 'org-src-lang-modes '("amm" . scala))
 
 (defcustom ob-ammonite-prompt-str "@"
   "Regex for ammonite prompt."


### PR DESCRIPTION
Hey thanks for this nice org extension!

The   org-src-lang-modes list contains cons-cell with symbols, not strings: `(("amm" . scala) ("arduino" . arduino) ("translate" . text) ("redis" . redis) ("php" . php) ("C" . c) ("C++" . c++) ("asymptote" . asy) ("bash" . sh) ...)`

It was causing `Wrong type argument: symbolp, "scala"` on tangling snippets.